### PR TITLE
Add jira common types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push]
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Ballerina Build
+              uses: ballerina-platform/ballerina-action/@master
+              with:
+                  args:
+                      build -a -c --skip-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Deployment
+on:
+    release:
+        types: [published]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Ballerina Build
+                uses: ballerina-platform/ballerina-action/@master
+                with:
+                    args:
+                        build -a -c --skip-tests
+            -   name: Ballerina Push
+                uses: ballerina-platform/ballerina-action/@master
+                with:
+                    args:
+                        push -a
+                env:
+                    BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+script:
+    - wget https://product-dist.ballerina.io/downloads/1.2.3/ballerina-linux-installer-x64-1.2.3.deb
+    - sudo dpkg -i ballerina-linux-installer-x64-1.2.3.deb
+    - sudo apt-get install -f
+    - ballerina --version
+    - ballerina build -a -c

--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,0 +1,4 @@
+org_name = "ballerinax"
+version = "0.1.0"
+lockfile_version = "1.0.0"
+ballerina_version = "1.2.4"

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,0 +1,5 @@
+[project]
+org-name= "ballerinax"
+version= "0.1.0"
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Module Overview
 
 The `ballerinax/jira.commons` module contains the common types for both the modules `ballerinax/jira` and `ballerinax
-/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products Jira Software
- and Jira Service Desk.
+/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products: `Jira Software`
+ and `Jira Service Desk`.
 
 Ballerina Jira Connectors:
 - [Jira Server Connector](https://github.com/ballerina-platform/module-ballerinax-jira)
@@ -16,34 +16,34 @@ Ballerina Jira Connectors:
 | JIRA SERVICE DESK API     |    3.6.2       |  
 
 ### Prerequisites
-Download the ballerina [distribution](https://ballerinalang.org/downloads/).
+Download and install [Ballerina](https://ballerinalang.org/downloads/).
 
 ### Pull and Install
 
 #### Pull the Module
-You can pull the `ballerinax/jira.commons` module from Ballerina Central:
+Execute the command below to pull the `ballerinax/jira.commons` module from Ballerina Central:
 ```shell
     $ ballerina pull ballerinax/jira.commons
 ```
 
 #### Install from Source
-Alternatively, you can install `ballerinax/jira.commons` module from the source using the following instructions.
+Alternatively, follow the instructions below to install the `ballerinax/jira.commons` module from the source.
 
 **Building the source**
-1. Clone this repository using the following command:
+1. Execute the command below to clone the source repository:
     ```shell
     $ git clone https://github.com/ballerina-platform/module-ballerinax-jira.commons.git
     ```
 
-2. Run this command from the `module-ballerinax-jira.commons` root directory:
+2. Navigate to the the `module-ballerinax-jira.commons` root directory and execute the command below:
     ```shell
     $ ballerina build -c commons 
     ```
 
 ### How you can contribute
 
-Clone the repository by running the following command
+Execute the command below to clone the repository:
 `git clone https://github.com/ballerina-platform/module-ballerinax-jira.commons.git`
 
 As an open source project, we welcome contributions from the community. Check the [issue tracker](https://github.com/ballerina-platform/module-ballerinax-jira.commons/issues) 
-for open issues that interest you. We look forward to receiving your contributions.
+for open issues that interest you. We look forward to receiving your contributions. For more information, see [Community](https://ballerina.io/community/).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# module-ballerinax-jira.commons
+# Module Overview
+
+The `ballerinax/jira.commons` module contains the common types for both the modules `ballerinax/jira` and `ballerinax
+/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products Jira Software
+ and Jira Service Desk.
+
+Ballerina Jira Connectors:
+- [Jira Server Connector](https://github.com/ballerina-platform/module-ballerinax-jira)
+- [Jira Service Desk Connector](https://github.com/ballerina-platform/module-ballerinax-jira.servicedesk)
+
+### Compatibility
+|                           |    Version     |  
+|:-------------------------:|:--------------:|
+| Ballerina Language        |    1.2.0       |
+| JIRA SERVER API           |    7.13.0      |  
+| JIRA SERVICE DESK API     |    3.6.2       |  
+
+### Prerequisites
+Download the ballerina [distribution](https://ballerinalang.org/downloads/).
+
+### Pull and Install
+
+#### Pull the Module
+You can pull the `ballerinax/jira.commons` module from Ballerina Central:
+```shell
+    $ ballerina pull ballerinax/jira.commons
+```
+
+#### Install from Source
+Alternatively, you can install `ballerinax/jira.commons` module from the source using the following instructions.
+
+**Building the source**
+1. Clone this repository using the following command:
+    ```shell
+    $ git clone https://github.com/ballerina-platform/module-ballerinax-jira.commons.git
+    ```
+
+2. Run this command from the `module-ballerinax-jira.commons` root directory:
+    ```shell
+    $ ballerina build -c commons 
+    ```
+
+### How you can contribute
+
+Clone the repository by running the following command
+`git clone https://github.com/ballerina-platform/module-ballerinax-jira.commons.git`
+
+As an open source project, we welcome contributions from the community. Check the [issue tracker](https://github.com/ballerina-platform/module-ballerinax-jira.commons/issues) 
+for open issues that interest you. We look forward to receiving your contributions.

--- a/src/commons/Module.md
+++ b/src/commons/Module.md
@@ -1,0 +1,16 @@
+# Module Overview
+
+The `ballerinax/jira.commons` module contains the common types for both the modules `ballerinax/jira` and `ballerinax
+/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products Jira Software
+ and Jira Service Desk.
+
+Ballerina Jira Connectors:
+- [Jira Server Connector](https://github.com/ballerina-platform/module-ballerinax-jira)
+- [Jira Service Desk Connector](https://github.com/ballerina-platform/module-ballerinax-jira.servicedesk)
+
+## Compatibility
+|                           |    Version     |  
+|:-------------------------:|:--------------:|
+| Ballerina Language        |    1.2.0       |
+| JIRA SERVER API           |    7.13.0      |  
+| JIRA SERVICE DESK API     |    3.6.2       |  

--- a/src/commons/Module.md
+++ b/src/commons/Module.md
@@ -1,8 +1,8 @@
 # Module Overview
 
 The `ballerinax/jira.commons` module contains the common types for both the modules `ballerinax/jira` and `ballerinax
-/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products Jira Software
- and Jira Service Desk.
+/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products: `Jira Software`
+ and `Jira Service Desk`.
 
 Ballerina Jira Connectors:
 - [Jira Server Connector](https://github.com/ballerina-platform/module-ballerinax-jira)

--- a/src/commons/types.bal
+++ b/src/commons/types.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/oauth2;
+
 # A summary of a Jira project.
 #
 # + resourcePath - The API resource URL
@@ -351,11 +353,20 @@ public type Comment record {
     string updatedDate?;
 };
 
-# Configurations related to the `Jira Client` endpoint initialization.
+# Configurations related to the client endpoint initialization.
 #
-# + baseUrl - The Jira API URL
-# + clientConfig - HTTP client endpoint configuration
-public type JiraConfiguration record {
+# + baseUrl - URL of the Jira instance
+# + authConfig - Client authentication configuration
+public type Configuration record {|
     string baseUrl;
-    http:ClientConfiguration clientConfig;
-};
+    BasicAuthConfiguration|oauth2:DirectTokenConfig authConfig;
+|};
+
+# Configuration to allow the clients to authenticate themselves using basic authentication.
+#
+# + username - Jira account username
+# + apiToken - Generated API token
+public type BasicAuthConfiguration record {|
+    string username;
+    string apiToken;
+|};

--- a/src/commons/types.bal
+++ b/src/commons/types.bal
@@ -24,7 +24,7 @@ import ballerina/http;
 # + name - The project name
 # + description - The project description
 # + category - The project category
-# + projectTypeKey - The type of the project(`software` or `business`)
+# + projectTypeKey - The type of the project: `software` or `business`
 public type ProjectSummary record {
     string resourcePath = "";
     string id = "";
@@ -43,12 +43,12 @@ public type ProjectSummary record {
 # + name - The project name
 # + description - The project description
 # + leadName - The Jira username of the project lead
-# + projectTypeKey - The type of the project(`software` or `business`)
+# + projectTypeKey - The type of the project: `software` or `business`
 # + avatarUrls - The project avatar URLs
-# + projectCategory - The details of project category
+# + projectCategory - The details of the project category
 # + issueTypes - The support issue types of the project
-# + components - THe summarized details about components of the project
-# + versions - The detatils of project versions
+# + components - The summarized details about the components of the project
+# + versions - The details of the project versions
 public type Project record {
     string resourcePath = "";
     string id = "";
@@ -69,16 +69,16 @@ public type Project record {
 # + key - The project key
 # + name - The project name
 # + description - The project description
-# + projectTypeKey - The type of the project(`software` or `business`)
+# + projectTypeKey - The type of the project: `software` or `business`
 # + projectTemplateKey - The template key of the project
 # + lead - The Jira username of the project lead
 # + url - The URL for the project
-# + assigneeType - The type of assignee of the project (`PROJECT_LEAD` or `UNASSIGNED`)
-# + avatarId - The avatar for the new project
-# + issueSecurityScheme - The issue security scheme id
-# + permissionScheme - The premission scheme id
-# + notificationScheme - The notification scheme id
-# + categoryId - The project category id
+# + assigneeType - The type of assignee of the project: `PROJECT_LEAD` or `UNASSIGNED`
+# + avatarId - The avatar of the new project
+# + issueSecurityScheme - The issue security scheme ID
+# + permissionScheme - The permission scheme ID
+# + notificationScheme - The notification scheme ID
+# + categoryId - The project category ID
 public type ProjectRequest record {
     string key = "";
     string name = "";
@@ -114,11 +114,11 @@ public type ProjectComponentSummary record {
 # + id - The project component ID
 # + name - The project component name
 # + description - The project component description
-# + leadName - Jira username of project component lead
-# + assigneeName - Jira username of component assignee
-# + assigneeType - Type of assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + leadName - Jira username of the project component lead
+# + assigneeName - Jira username of the component assignee
+# + assigneeType - Type of assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD`, or `UNASSIGNED`)
 # + realAssigneeName - Jira username of the project component real assignee
-# + realAssigneeType - Type of real assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + realAssigneeType - Type of the real assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD`, or `UNASSIGNED`)
 # + project - Key of the related project
 # + projectId - ID of the related project
 public type ProjectComponent record {
@@ -139,8 +139,8 @@ public type ProjectComponent record {
 #
 # + name - The project component name
 # + description - The project component description
-# + leadUserName - Jira username of project component lead
-# + assigneeType - Type of assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + leadUserName - Jira username of the project component lead
+# + assigneeType - Type of the assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD`, or `UNASSIGNED`)
 # + project - Key of the related project
 # + projectId - The ID of the related project
 public type ProjectComponentRequest record {
@@ -165,7 +165,7 @@ public type ProjectCategory record {
     string description = "";
 };
 
-# Represents Jira project category creation template object.
+# Represents the Jira project category creation template object.
 #
 # + name - Project category name
 # + description - Project category description
@@ -174,7 +174,7 @@ public type ProjectCategoryRequest record {
     string description = "";
 };
 
-# Jira issue type status related to a Jira project.).
+# Jira issue type status related to a Jira project.
 #
 # + resourcePath - The API resource URL
 # + name - The related issue type name
@@ -189,7 +189,7 @@ public type ProjectStatus record {
 
 # Detail record of a Jira user.
 #
-# + accountId - The account ID of the User
+# + accountId - The account ID of the user
 # + resourcePath - The API resource URL
 # + key - The key of the user
 # + name - The name of the user
@@ -280,10 +280,10 @@ public type AvatarUrls record {
 # + createdDate - The date the issue was created
 # + dueDate - The due date of the issue
 # + timespent - The assigned time for the issue
-# + issueType - The type of the jira issue
-# + project - Summarized details of the project which the issue is related to
+# + issueType - The type of the Jira issue
+# + project - Summarized details of the project to which the issue is related 
 # + comments - The comments on the issue
-# + customFields - Custom fields which contain the details of the issue
+# + customFields - Custom fields, which contain the details of the issue
 # + resolutionDate -The date of resolution
 # + aggregatetimespent - The time spent on the issue
 public type Issue record {
@@ -328,7 +328,7 @@ public type IssueRequest record {
 # + key - The issue key
 # + priorityId - The issue priority ID
 # + statusId - Issue status ID
-# + issueType - The type of the jira issue
+# + issueType - The type of the Jira issue
 public type IssueSummary record {
     string resourcePath = "";
     string id = "";
@@ -340,8 +340,8 @@ public type IssueSummary record {
 
 # Detail record of a comment on a Jira issue.
 #
-# + id - The issue ID to which the comment belongs to
-# + authorName - The authors name of the comment
+# + id - The issue ID to which the comment belongs 
+# + authorName - The author's name of the comment
 # + authorKey - The author's key
 # + body - The body of the comment
 # + updatedDate - The date of creation of the comment
@@ -353,7 +353,7 @@ public type Comment record {
     string updatedDate = "";
 };
 
-# Configurations related to `Jira Client` endpoint initialization.
+# Configurations related to the `Jira Client` endpoint initialization.
 #
 # + baseUrl - The Jira API URL
 # + clientConfig - HTTP client endpoint configuration

--- a/src/commons/types.bal
+++ b/src/commons/types.bal
@@ -1,0 +1,363 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+# A summary of a Jira project.
+#
+# + resourcePath - The API resource URL
+# + id - The project ID
+# + key - The project key
+# + name - The project name
+# + description - The project description
+# + category - The project category
+# + projectTypeKey - The type of the project(`software` or `business`)
+public type ProjectSummary record {
+    string resourcePath = "";
+    string id = "";
+    string key = "";
+    string name = "";
+    string description = "";
+    string category = "";
+    string projectTypeKey = "";
+};
+
+# Detail record of a Jira project.
+#
+# + resourcePath - The API resource URL
+# + id - The project ID
+# + key - The project key
+# + name - The project name
+# + description - The project description
+# + leadName - The Jira username of the project lead
+# + projectTypeKey - The type of the project(`software` or `business`)
+# + avatarUrls - The project avatar URLs
+# + projectCategory - The details of project category
+# + issueTypes - The support issue types of the project
+# + components - THe summarized details about components of the project
+# + versions - The detatils of project versions
+public type Project record {
+    string resourcePath = "";
+    string id = "";
+    string key = "";
+    string name = "";
+    string description = "";
+    string leadName = "";
+    string projectTypeKey = "";
+    AvatarUrls avatarUrls = {};
+    ProjectCategory projectCategory = {};
+    IssueType[] issueTypes = [];
+    ProjectComponentSummary[] components = [];
+    ProjectVersion[] versions = [];
+};
+
+# The Jira project creation/update template.
+#
+# + key - The project key
+# + name - The project name
+# + description - The project description
+# + projectTypeKey - The type of the project(`software` or `business`)
+# + projectTemplateKey - The template key of the project
+# + lead - The Jira username of the project lead
+# + url - The URL for the project
+# + assigneeType - The type of assignee of the project (`PROJECT_LEAD` or `UNASSIGNED`)
+# + avatarId - The avatar for the new project
+# + issueSecurityScheme - The issue security scheme id
+# + permissionScheme - The premission scheme id
+# + notificationScheme - The notification scheme id
+# + categoryId - The project category id
+public type ProjectRequest record {
+    string key = "";
+    string name = "";
+    string projectTypeKey = "";
+    string projectTemplateKey = "";
+    string description = "";
+    string lead = "";
+    string url = "";
+    string assigneeType = "";
+    string avatarId = "";
+    string issueSecurityScheme = "";
+    string permissionScheme = "";
+    string notificationScheme = "";
+    string categoryId = "";
+};
+
+# Summary of a Jira project component.
+#
+# + resourcePath - The API resource URL
+# + id - The project component ID
+# + name - The project component name
+# + description - Project component description
+public type ProjectComponentSummary record {
+    string resourcePath = "";
+    string id = "";
+    string name = "";
+    string description = "";
+};
+
+# Detail record of a Jira project component.
+#
+# + resourcePath - The API resource URL
+# + id - The project component ID
+# + name - The project component name
+# + description - The project component description
+# + leadName - Jira username of project component lead
+# + assigneeName - Jira username of component assignee
+# + assigneeType - Type of assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + realAssigneeName - Jira username of the project component real assignee
+# + realAssigneeType - Type of real assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + project - Key of the related project
+# + projectId - ID of the related project
+public type ProjectComponent record {
+    string resourcePath = "";
+    string id = "";
+    string name = "";
+    string description = "";
+    string leadName = "";
+    string assigneeName = "";
+    string assigneeType = "";
+    string realAssigneeName = "";
+    string realAssigneeType = "";
+    string project = "";
+    string projectId = "";
+};
+
+# Jira project component creation template.
+#
+# + name - The project component name
+# + description - The project component description
+# + leadUserName - Jira username of project component lead
+# + assigneeType - Type of assignee (`PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD` or `UNASSIGNED`)
+# + project - Key of the related project
+# + projectId - The ID of the related project
+public type ProjectComponentRequest record {
+    string name = "";
+    string description = "";
+    string leadUserName = "";
+    string assigneeType = "";
+    string project = "";
+    string projectId = "";
+};
+
+# Detail record of a Jira project category.
+#
+# + resourcePath - The API resource URL
+# + id - The project category ID
+# + name - The project category name
+# + description - The project category description
+public type ProjectCategory record {
+    string resourcePath = "";
+    string id = "";
+    string name = "";
+    string description = "";
+};
+
+# Represents Jira project category creation template object.
+#
+# + name - Project category name
+# + description - Project category description
+public type ProjectCategoryRequest record {
+    string name = "";
+    string description = "";
+};
+
+# Jira issue type status related to a Jira project.).
+#
+# + resourcePath - The API resource URL
+# + name - The related issue type name
+# + id - The related issue type ID
+# + statuses - Project status details related to the issue type
+public type ProjectStatus record {
+    string resourcePath = "";
+    string name = "";
+    string id = "";
+    json[] statuses = [];
+};
+
+# Detail record of a Jira user.
+#
+# + accountId - The account ID of the User
+# + resourcePath - The API resource URL
+# + key - The key of the user
+# + name - The name of the user
+# + displayName - The display name of the user
+# + emailAddress - The email address of the user
+# + avatarUrls - The avatar URLs of the user
+# + active - Indicates whether the user is active
+# + timeZone - Time zone related to the user
+# + locale - The user's locale
+public type User record {
+    string accountId = "";
+    string resourcePath = "";
+    string key = "";
+    string name = "";
+    string displayName = "";
+    string emailAddress = "";
+    json avatarUrls = {};
+    boolean active = false;
+    string timeZone = "";
+    string locale = "";
+};
+
+# Detail record of a Jira issue type.
+#
+# + resourcePath - The API resource URL
+# + id - The issue type ID
+# + name - The issue type name
+# + description - The issue type description
+# + iconUrl - The URL of the issue type icon
+# + avatarId - The avatar ID
+public type IssueType record {
+    string resourcePath = "";
+    string id = "";
+    string name = "";
+    string description = "";
+    string iconUrl = "";
+    string avatarId = "";
+};
+
+# Detail record of a Jira project version.
+#
+# + resourcePath - The API resource URL
+# + id - The project version ID
+# + name - The project version name
+# + archived - Indicates whether the version is archived
+# + released - Indicates whether the version is released
+# + releaseDate - The release date of the project version
+# + overdue - Indicates whether the version is overdue
+# + userReleaseDate - User release date of the project version
+# + projectId - ID of the related project
+public type ProjectVersion record {
+    string resourcePath = "";
+    string id = "";
+    string name = "";
+    boolean archived = false;
+    boolean released = false;
+    string releaseDate = "";
+    boolean overdue = false;
+    string userReleaseDate = "";
+    string projectId = "";
+};
+
+# Set of avatar URLs related to a Jira entity.
+#
+# + '16x16 - Avatar URL icon of size 16x16
+# + '24x24 - Avatar URL icon of size 24x24
+# + '32x32 - Avatar URL icon of size 32x32
+# + '48x48 - Avatar URL icon of size 48x48
+public type AvatarUrls record {
+    string '16x16 = "";
+    string '24x24 = "";
+    string '32x32 = "";
+    string '48x48 = "";
+};
+
+# Detail record of a Jira issue.
+#
+# + resourcePath - The API resource URL
+# + id - The issue ID
+# + key - The issue key
+# + summary - The summary of the issue
+# + priorityId - The issue priority ID
+# + resolutionId - The issue resolution ID
+# + statusId - The issue status ID
+# + creatorName - The Jira username of the issue creator
+# + assigneeName - The Jira username of the issue assignee
+# + reporterName - The Jira username of the issue reporter
+# + createdDate - The date the issue was created
+# + dueDate - The due date of the issue
+# + timespent - The assigned time for the issue
+# + issueType - The type of the jira issue
+# + project - Summarized details of the project which the issue is related to
+# + comments - The comments on the issue
+# + customFields - Custom fields which contain the details of the issue
+# + resolutionDate -The date of resolution
+# + aggregatetimespent - The time spent on the issue
+public type Issue record {
+    string resourcePath = "";
+    string id = "";
+    string key = "";
+    string summary = "";
+    string priorityId = "";
+    string resolutionId = "";
+    string statusId = "";
+    string creatorName = "";
+    string assigneeName = "";
+    string reporterName = "";
+    string createdDate = "";
+    string dueDate = "";
+    string timespent = "";
+    string resolutionDate = "";
+    string aggregatetimespent = "";
+    IssueType issueType = {};
+    ProjectSummary project = {};
+    Comment[] comments = [];
+    json[] customFields = [];
+};
+
+# Jira issue creation template.
+#
+# + summary - The summary of the issue
+# + issueTypeId - The ID of the issue type for the new issue
+# + projectId - The ID of the project related to the new issue
+# + assigneeName - The Jira username of the issue assignee
+public type IssueRequest record {
+    string summary = "";
+    string issueTypeId = "";
+    string projectId = "";
+    string assigneeName = "";
+};
+
+# Detail record of a Jira issue summary.
+#
+# + resourcePath - The API resource URL
+# + id - The issue ID
+# + key - The issue key
+# + priorityId - The issue priority ID
+# + statusId - Issue status ID
+# + issueType - The type of the jira issue
+public type IssueSummary record {
+    string resourcePath = "";
+    string id = "";
+    string key = "";
+    string priorityId = "";
+    string statusId = "";
+    IssueType issueType = {};
+};
+
+# Detail record of a comment on a Jira issue.
+#
+# + id - The issue ID to which the comment belongs to
+# + authorName - The authors name of the comment
+# + authorKey - The author's key
+# + body - The body of the comment
+# + updatedDate - The date of creation of the comment
+public type Comment record {
+    string id = "";
+    string authorName = "";
+    string authorKey = "";
+    string body = "";
+    string updatedDate = "";
+};
+
+# Configurations related to `Jira Client` endpoint initialization.
+#
+# + baseUrl - The Jira API URL
+# + clientConfig - HTTP client endpoint configuration
+public type JiraConfiguration record {
+    string baseUrl;
+    http:ClientConfiguration clientConfig;
+};

--- a/src/commons/types.bal
+++ b/src/commons/types.bal
@@ -14,8 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
-
 # A summary of a Jira project.
 #
 # + resourcePath - The API resource URL
@@ -26,13 +24,13 @@ import ballerina/http;
 # + category - The project category
 # + projectTypeKey - The type of the project(`software` or `business`)
 public type ProjectSummary record {
-    string resourcePath = "";
-    string id = "";
-    string key = "";
-    string name = "";
-    string description = "";
-    string category = "";
-    string projectTypeKey = "";
+    string resourcePath?;
+    string id?;
+    string key?;
+    string name?;
+    string description?;
+    string category?;
+    string projectTypeKey?;
 };
 
 # Detail record of a Jira project.
@@ -50,18 +48,18 @@ public type ProjectSummary record {
 # + components - THe summarized details about components of the project
 # + versions - The detatils of project versions
 public type Project record {
-    string resourcePath = "";
-    string id = "";
-    string key = "";
-    string name = "";
-    string description = "";
-    string leadName = "";
-    string projectTypeKey = "";
-    AvatarUrls avatarUrls = {};
-    ProjectCategory projectCategory = {};
-    IssueType[] issueTypes = [];
-    ProjectComponentSummary[] components = [];
-    ProjectVersion[] versions = [];
+    string resourcePath?;
+    string id?;
+    string key?;
+    string name?;
+    string description?;
+    string leadName?;
+    string projectTypeKey?;
+    AvatarUrls avatarUrls?;
+    ProjectCategory projectCategory?;
+    IssueType[] issueTypes?;
+    ProjectComponentSummary[] components?;
+    ProjectVersion[] versions?;
 };
 
 # The Jira project creation/update template.
@@ -80,19 +78,19 @@ public type Project record {
 # + notificationScheme - The notification scheme id
 # + categoryId - The project category id
 public type ProjectRequest record {
-    string key = "";
-    string name = "";
-    string projectTypeKey = "";
-    string projectTemplateKey = "";
-    string description = "";
-    string lead = "";
-    string url = "";
-    string assigneeType = "";
-    string avatarId = "";
-    string issueSecurityScheme = "";
-    string permissionScheme = "";
-    string notificationScheme = "";
-    string categoryId = "";
+    string key?;
+    string name?;
+    string projectTypeKey?;
+    string projectTemplateKey?;
+    string description?;
+    string lead?;
+    string url?;
+    string assigneeType?;
+    string avatarId?;
+    string issueSecurityScheme?;
+    string permissionScheme?;
+    string notificationScheme?;
+    string categoryId?;
 };
 
 # Summary of a Jira project component.
@@ -102,10 +100,10 @@ public type ProjectRequest record {
 # + name - The project component name
 # + description - Project component description
 public type ProjectComponentSummary record {
-    string resourcePath = "";
-    string id = "";
-    string name = "";
-    string description = "";
+    string resourcePath?;
+    string id?;
+    string name?;
+    string description?;
 };
 
 # Detail record of a Jira project component.
@@ -122,17 +120,17 @@ public type ProjectComponentSummary record {
 # + project - Key of the related project
 # + projectId - ID of the related project
 public type ProjectComponent record {
-    string resourcePath = "";
-    string id = "";
-    string name = "";
-    string description = "";
-    string leadName = "";
-    string assigneeName = "";
-    string assigneeType = "";
-    string realAssigneeName = "";
-    string realAssigneeType = "";
-    string project = "";
-    string projectId = "";
+    string resourcePath?;
+    string id?;
+    string name?;
+    string description?;
+    string leadName?;
+    string assigneeName?;
+    string assigneeType?;
+    string realAssigneeName?;
+    string realAssigneeType?;
+    string project?;
+    string projectId?;
 };
 
 # Jira project component creation template.
@@ -144,12 +142,12 @@ public type ProjectComponent record {
 # + project - Key of the related project
 # + projectId - The ID of the related project
 public type ProjectComponentRequest record {
-    string name = "";
-    string description = "";
-    string leadUserName = "";
-    string assigneeType = "";
-    string project = "";
-    string projectId = "";
+    string name?;
+    string description?;
+    string leadUserName?;
+    string assigneeType?;
+    string project?;
+    string projectId?;
 };
 
 # Detail record of a Jira project category.
@@ -159,10 +157,10 @@ public type ProjectComponentRequest record {
 # + name - The project category name
 # + description - The project category description
 public type ProjectCategory record {
-    string resourcePath = "";
-    string id = "";
-    string name = "";
-    string description = "";
+    string resourcePath?;
+    string id?;
+    string name?;
+    string description?;
 };
 
 # Represents Jira project category creation template object.
@@ -170,8 +168,8 @@ public type ProjectCategory record {
 # + name - Project category name
 # + description - Project category description
 public type ProjectCategoryRequest record {
-    string name = "";
-    string description = "";
+    string name?;
+    string description?;
 };
 
 # Jira issue type status related to a Jira project.).
@@ -181,10 +179,10 @@ public type ProjectCategoryRequest record {
 # + id - The related issue type ID
 # + statuses - Project status details related to the issue type
 public type ProjectStatus record {
-    string resourcePath = "";
-    string name = "";
-    string id = "";
-    json[] statuses = [];
+    string resourcePath?;
+    string name?;
+    string id?;
+    json[] statuses?;
 };
 
 # Detail record of a Jira user.
@@ -200,16 +198,16 @@ public type ProjectStatus record {
 # + timeZone - Time zone related to the user
 # + locale - The user's locale
 public type User record {
-    string accountId = "";
-    string resourcePath = "";
-    string key = "";
-    string name = "";
-    string displayName = "";
-    string emailAddress = "";
-    json avatarUrls = {};
+    string accountId?;
+    string resourcePath?;
+    string key?;
+    string name?;
+    string displayName?;
+    string emailAddress?;
+    json avatarUrls?;
     boolean active = false;
-    string timeZone = "";
-    string locale = "";
+    string timeZone?;
+    string locale?;
 };
 
 # Detail record of a Jira issue type.
@@ -221,12 +219,12 @@ public type User record {
 # + iconUrl - The URL of the issue type icon
 # + avatarId - The avatar ID
 public type IssueType record {
-    string resourcePath = "";
-    string id = "";
-    string name = "";
-    string description = "";
-    string iconUrl = "";
-    string avatarId = "";
+    string resourcePath?;
+    string id?;
+    string name?;
+    string description?;
+    string iconUrl?;
+    string avatarId?;
 };
 
 # Detail record of a Jira project version.
@@ -241,15 +239,15 @@ public type IssueType record {
 # + userReleaseDate - User release date of the project version
 # + projectId - ID of the related project
 public type ProjectVersion record {
-    string resourcePath = "";
-    string id = "";
-    string name = "";
+    string resourcePath?;
+    string id?;
+    string name?;
     boolean archived = false;
     boolean released = false;
-    string releaseDate = "";
+    string releaseDate?;
     boolean overdue = false;
-    string userReleaseDate = "";
-    string projectId = "";
+    string userReleaseDate?;
+    string projectId?;
 };
 
 # Set of avatar URLs related to a Jira entity.
@@ -259,10 +257,10 @@ public type ProjectVersion record {
 # + '32x32 - Avatar URL icon of size 32x32
 # + '48x48 - Avatar URL icon of size 48x48
 public type AvatarUrls record {
-    string '16x16 = "";
-    string '24x24 = "";
-    string '32x32 = "";
-    string '48x48 = "";
+    string '16x16?;
+    string '24x24?;
+    string '32x32?;
+    string '48x48?;
 };
 
 # Detail record of a Jira issue.
@@ -287,25 +285,25 @@ public type AvatarUrls record {
 # + resolutionDate -The date of resolution
 # + aggregatetimespent - The time spent on the issue
 public type Issue record {
-    string resourcePath = "";
-    string id = "";
-    string key = "";
-    string summary = "";
-    string priorityId = "";
-    string resolutionId = "";
-    string statusId = "";
-    string creatorName = "";
-    string assigneeName = "";
-    string reporterName = "";
-    string createdDate = "";
-    string dueDate = "";
-    string timespent = "";
-    string resolutionDate = "";
-    string aggregatetimespent = "";
-    IssueType issueType = {};
-    ProjectSummary project = {};
-    Comment[] comments = [];
-    json[] customFields = [];
+    string resourcePath?;
+    string id?;
+    string key?;
+    string summary?;
+    string priorityId?;
+    string resolutionId?;
+    string statusId?;
+    string creatorName?;
+    string assigneeName?;
+    string reporterName?;
+    string createdDate?;
+    string dueDate?;
+    string timespent?;
+    string resolutionDate?;
+    string aggregatetimespent?;
+    IssueType issueType?;
+    ProjectSummary project?;
+    Comment[] comments?;
+    json[] customFields?;
 };
 
 # Jira issue creation template.
@@ -315,10 +313,10 @@ public type Issue record {
 # + projectId - The ID of the project related to the new issue
 # + assigneeName - The Jira username of the issue assignee
 public type IssueRequest record {
-    string summary = "";
-    string issueTypeId = "";
-    string projectId = "";
-    string assigneeName = "";
+    string summary?;
+    string issueTypeId?;
+    string projectId?;
+    string assigneeName?;
 };
 
 # Detail record of a Jira issue summary.
@@ -330,12 +328,12 @@ public type IssueRequest record {
 # + statusId - Issue status ID
 # + issueType - The type of the jira issue
 public type IssueSummary record {
-    string resourcePath = "";
-    string id = "";
-    string key = "";
-    string priorityId = "";
-    string statusId = "";
-    IssueType issueType = {};
+    string resourcePath?;
+    string id?;
+    string key?;
+    string priorityId?;
+    string statusId?;
+    IssueType issueType?;
 };
 
 # Detail record of a comment on a Jira issue.
@@ -346,11 +344,11 @@ public type IssueSummary record {
 # + body - The body of the comment
 # + updatedDate - The date of creation of the comment
 public type Comment record {
-    string id = "";
-    string authorName = "";
-    string authorKey = "";
-    string body = "";
-    string updatedDate = "";
+    string id?;
+    string authorName?;
+    string authorKey?;
+    string body?;
+    string updatedDate?;
 };
 
 # Configurations related to `Jira Client` endpoint initialization.


### PR DESCRIPTION
## Purpose
The `ballerinax/jira.commons` module contains the common types for both the modules `ballerinax/jira` and `ballerinax
/jira.servicedesk`. This module acts as a library for the shared components between the two Jira products Jira Software
 and Jira Service Desk.

Ballerina Jira Connectors:
- [Jira Server Connector](https://github.com/ballerina-platform/module-ballerinax-jira)
- [Jira Service Desk Connector](https://github.com/ballerina-platform/module-ballerinax-jira.servicedesk) 
